### PR TITLE
Add a FontManager to better support loading fonts

### DIFF
--- a/ImTool/FontManager.cs
+++ b/ImTool/FontManager.cs
@@ -1,0 +1,82 @@
+﻿using ImGuiNET;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ImTool
+{
+    public static class FontManager
+    {
+        private static Configuration config;
+
+        public static Dictionary<string, ImFontPtr> RuntimeFonts { get; private set; }
+
+        public static Dictionary<string, ImToolFontObj> QueuedFonts;
+
+        public static string DefaultFont = "";
+
+        private static bool initialized;
+
+        public static void Initialize(Configuration configuration)
+        {
+            if (initialized)
+            {
+                return;
+            }
+
+            config = configuration;
+
+            RuntimeFonts = new Dictionary<string, ImFontPtr>();
+            QueuedFonts = new Dictionary<string, ImToolFontObj>();
+
+            initialized = true;
+        }
+
+        public static void LoadFont(string fontName, string filePath, float fontSize)
+        {
+            if (RuntimeFonts.ContainsKey(fontName) == false && QueuedFonts.ContainsKey(fontName) == false && System.IO.File.Exists(filePath))
+            {
+                QueuedFonts.Add(fontName, new ImToolFontObj(fontName, filePath, fontSize));
+            }
+        }
+
+        public static void UnloadFont(string fontName)
+        {
+            if (RuntimeFonts.ContainsKey(fontName))
+            {
+
+            }
+        }
+
+        static public ImFontPtr GetFont(string fontName)
+        {
+            if (RuntimeFonts.ContainsKey(fontName))
+            {
+                return RuntimeFonts[fontName];
+            }
+
+            return ImGui.GetIO().FontDefault;
+        }
+    }
+
+    public class ImToolFontObj
+    {
+        public string FontName = "";
+        public string FontFilePath = "";
+        public float FontSize = 13.0f;
+
+        public ImToolFontObj()
+        {
+
+        }
+
+        public ImToolFontObj(string fontName, string fontFilePath, float fontSize)
+        {
+            FontName = fontName;
+            FontFilePath = fontFilePath;
+            FontSize = fontSize;
+        }
+    }
+}

--- a/ImTool/ImGui/ImGuiController.cs
+++ b/ImTool/ImGui/ImGuiController.cs
@@ -75,6 +75,8 @@ namespace ImGuiNET
         private int _lastAssignedID = 100;
 
         private Dictionary<Font, ImFontPtr> fonts = new();
+        private Dictionary<string, ImFontPtr> runtimeFonts = new();
+        private Dictionary<string, string> fontLoadQueue = new();
 
         /// <summary>
         /// Constructs a new ImGuiController.
@@ -161,7 +163,8 @@ namespace ImGuiNET
             }
             
             LoadFonts();
-            
+            LoadQueuedFonts();
+
             CreateDeviceResources(gd, outputDescription);
             SetKeyMappings();
 
@@ -235,6 +238,25 @@ namespace ImGuiNET
                 }
                 
             }
+        }
+        private void LoadQueuedFonts()
+        {
+            if (FontManager.QueuedFonts.Count > 0)
+            {
+                foreach (KeyValuePair<string, ImToolFontObj> item in FontManager.QueuedFonts)
+                {
+                    LoadLooseQueuedFont(item.Key, item.Value.FontFilePath, item.Value.FontSize);
+                }
+                FontManager.QueuedFonts.Clear();
+                RecreateFontDeviceTexture(_gd);
+            }
+        }
+
+        private void LoadLooseQueuedFont(string name, string path, float size)
+        {
+            ImFontPtr imFontPtr = new ImFontPtr();
+            imFontPtr = ImGui.GetIO().Fonts.AddFontFromFileTTF(path, size);
+            FontManager.RuntimeFonts.Add(name, imFontPtr);
         }
 
         private void CreateWindow(ImGuiViewportPtr vp)

--- a/ImTool/Tool.cs
+++ b/ImTool/Tool.cs
@@ -29,7 +29,9 @@ namespace ImTool
                 Directory.CreateDirectory(toolDataBasePath);
             
             Updater = new Updater(Config);
-            
+
+            FontManager.Initialize(Config);
+
             if(!Initialize(Environment.GetCommandLineArgs()))
                 return;
             

--- a/ImTool/Window.cs
+++ b/ImTool/Window.cs
@@ -211,6 +211,10 @@ namespace ImTool
         
         private unsafe void SubmitUI()
         {
+            if (FontManager.DefaultFont != "" && FontManager.RuntimeFonts.ContainsKey(FontManager.DefaultFont))
+            {
+                ImGui.PushFont(FontManager.RuntimeFonts[FontManager.DefaultFont]);
+            }
             ImGui.SetNextWindowSize(windowBounds.Size);
             ImGui.SetNextWindowPos(windowBounds.Position);
             MainWindowStyleOverrides(true);


### PR DESCRIPTION
This resolves the initial part of #19 for allowing implementing applications to load custom fonts. However, it currently only supports providing paths to loose font files. Until it supports loading fonts from memory is serves as an addon to the exist basic font support internal to ImTool. When this support is added, some FontManager related variables should be renamed to better fit generic Font support.

Memory font loading can most likely be supported in `FontManager` by adding a new variable to `ImToolFontObj` for providing a `Stream` to read from in place of the `FontFilePath`

How implementing applications utilize FontManager:
During the overridden ImTool `Initialize()` function they make calls to `FontManager.LoadFont` such as `ImTool.FontManager.LoadFont("SegoeUI", @"C:\Windows\Fonts\segoeui.ttf", 18.0f);`

If the application wants to use a new default font across all of ImTool, they can then call `FontManager.DefaultFont` to set a previously loaded font (via LoadFont) to be used. For example: `ImTool.FontManager.DefaultFont = "SegoeUI";`

To obtain the `ImFontPtr` for pushing a font applications can use `FontManager.GetFont` such as `ImGui.PushFont(FontManager.GetFont("SegoeUI"));`. If the font specified does not exist the current flow of FontManager is to return `ImGui.GetIO().FontDefault`.